### PR TITLE
Fix path matching

### DIFF
--- a/src/partials/PrimaryNavigation.tsx
+++ b/src/partials/PrimaryNavigation.tsx
@@ -41,8 +41,14 @@ const isPageInPath = (
 ) => {
   let m: Reflection | undefined;
   for (m = page; m && !m.isProject(); m = m.parent) {
-    if (m === node) return true;
-    if (m.kindOf(ReflectionKind.Module) && `/${m.name}`.startsWith(path)) return true;
+    if (m === node) {
+      return true;
+    }
+
+    const p = `/${m.name}`;
+    if (m.kindOf(ReflectionKind.Module) && (p === path || p.startsWith(`${path}/`))) {
+      return true;
+    }
   }
   return false;
 };


### PR DESCRIPTION
Fix the following bug:

## Condition
There's a module whose path contains another module path, e.g. `path/to/fooX` vs. `path/to/foo`

## Expected
Only `path/to/fooX` should be displayed as "current" in the hierarchy tree.

## Actual
`path/to/foo` is also displayed as "current" in the hierarchy tree.