### PR TITLE
Show secondary navigation if necessary

### DIFF
--- a/src/RenderContext.tsx
+++ b/src/RenderContext.tsx
@@ -9,13 +9,21 @@ import Breadcrumb from './partials/Breadcrumb';
 import Navigation from './partials/Navigation';
 
 class RenderContext extends DefaultThemeRenderContext {
-  override breadcrumb = (model: Reflection) => (
-    <Breadcrumb context={this} model={model} />
-  );
+  constructor(...args: ConstructorParameters<typeof DefaultThemeRenderContext>) {
+    super(...args);
 
-  override navigation = ({ model }: PageEvent<Reflection>) => (
-    <Navigation context={this} model={model} />
-  );
+    // We want to overwrite members using `this` and `super`,
+    // yet they're not methods but properties.
+    // So we have to overwrite them in the constructor.
+
+    this.breadcrumb = (model: Reflection) => <Breadcrumb context={this} model={model} />;
+
+    const originalNavigation = this.navigation;
+    this.navigation = (pageEvent: PageEvent<Reflection>) => {
+      const original = originalNavigation(pageEvent);
+      return <Navigation context={this} model={pageEvent.model} original={original} />;
+    };
+  }
 }
 
 export default RenderContext;

--- a/src/partials/Navigation.tsx
+++ b/src/partials/Navigation.tsx
@@ -1,21 +1,32 @@
-import { JSX, Reflection } from 'typedoc';
+import {
+  JSX,
+  Reflection,
+  ReflectionKind,
+} from 'typedoc';
 
 import RenderContext from '../RenderContext';
 import PrimaryNavigation from './PrimaryNavigation';
 
 type NavigationProps = {
   context: RenderContext,
-  /** model of a target page */
   model: Reflection,
+  original: JSX.Element,
 };
 
-/**
- * Replacement of the DefaultTheme's navigation menu
- *
- * We don't need secondary navigation because they are included in primary navigation.
- */
-const Navigation = ({ context, model }: NavigationProps): JSX.Element => (
-  <PrimaryNavigation {...{ context, model }} />
-);
+/** Replacement of the DefaultTheme's navigation menu */
+const Navigation = ({ context, model, original }: NavigationProps): JSX.Element => {
+  const modules = model.project.getChildrenByKind(ReflectionKind.SomeModule);
+  const projectHasModule = modules.some((m) => m.kindOf(ReflectionKind.Module));
+
+  // original secondary navigation
+  const secondaryNavigation = original.children.length === 2 && original.children[1];
+
+  return (
+    <>
+      <PrimaryNavigation {...{ context, model, projectHasModule }} />
+      {!projectHasModule && secondaryNavigation}
+    </>
+  );
+};
 
 export default Navigation;

--- a/src/partials/PrimaryNavigation.tsx
+++ b/src/partials/PrimaryNavigation.tsx
@@ -116,32 +116,33 @@ const TreeView = ({
 
 type PrimaryNavigationProps = {
   context: RenderContext,
-  /** model of a target page */
   model: Reflection,
+  projectHasModule: boolean,
 };
 
 /** Tree view of categories and modules */
-const PrimaryNavigation = ({ context, model }: PrimaryNavigationProps): JSX.Element => {
-  const modules = model.project.getChildrenByKind(ReflectionKind.SomeModule);
-  const projectLinkName = modules.some((m) => m.kindOf(ReflectionKind.Module)) ? 'Modules' : 'Exports';
-
-  return (
-    <nav class="tsd-navigation primary">
-      <ul>
-        <li class={clsx('project', { current: model.isProject() })}>
-          <a class="menu-label" href={context.urlTo(model.project)}>{projectLinkName}</a>
+const PrimaryNavigation = ({
+  context,
+  model,
+  projectHasModule,
+}: PrimaryNavigationProps): JSX.Element => (
+  <nav class="tsd-navigation primary">
+    <ul>
+      <li class={clsx('project', { current: model.isProject() })}>
+        <a class="menu-label" href={context.urlTo(model.project)}>{projectHasModule ? 'Modules' : 'Exports'}</a>
+        {model.project.categories && (
           <ul>
-            {(model.project.categories || []).map((category) => (
+            {model.project.categories.map((category) => (
               <li class={clsx('category', { current: isPageInCategory(model, category) })}>
                 <div class="menu-label">{category.title}</div>
                 <TreeView tree={toTree(category.children)} {...{ context, model }} />
               </li>
             ))}
           </ul>
-        </li>
-      </ul>
-    </nav>
-  );
-};
+        )}
+      </li>
+    </ul>
+  </nav>
+);
 
 export default PrimaryNavigation;

--- a/static/custom.css
+++ b/static/custom.css
@@ -46,6 +46,9 @@
 
 .tsd-navigation.primary li.project > .menu-label {
   border-bottom: 1px solid var(--color-panel-divider);
+  border-top: 1px solid var(--color-panel-divider);
+  padding-bottom: 6px;
+  padding-top: 6px;
 }
 
 .tsd-navigation.primary li.category > .menu-label {
@@ -83,6 +86,7 @@
 .tsd-navigation.primary li > .menu-label {
   color: var(--color-menu-label);
   padding-bottom: 3px;
+  padding-left: 5px;
   padding-top: 3px;
 }
 


### PR DESCRIPTION
Fixed the following bug, with tweaking design a bit:

## Condition
When displaying "Exports"

## Expected
The secondary navigation should be displayed.

## Actual
Only the primary navigation is always displayed.

## Note
We needed to extract the secondary navigation from the original rendering result because recent TypeDoc has prevented us accessing inner implementations by setting "exports" in package.json.